### PR TITLE
Add back support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "laravel/framework": "^9.0",
+    "laravel/framework": "^8.0|^9.0",
     "laravel/passport": "^10.0"
   },
   "autoload": {


### PR DESCRIPTION
We don't see any reason that currently only Laravel 9 should be supported. Hopefully 8.0 support can be added back. :)